### PR TITLE
added marimo-spark 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM apache/spark:4.1.1-java21-python3
+
+USER root
+
+RUN pip install --no-cache-dir \
+    "delta-spark==4.1.0" \
+    "marimo[recommended]>=0.20.1" \
+    "nbconvert>=7.17.0" \
+    "numpy>=2.2.6" \
+    "playwright>=1.58.0" \
+    "pyspark==4.1.1"
+
+RUN playwright install --with-deps chromium
+
+WORKDIR /opt/workspace
+
+COPY marimo-playground/ ./marimo-playground/
+
+EXPOSE 2718
+
+ENTRYPOINT ["marimo", "edit", "--host", "0.0.0.0", "--port", "2718", "marimo-playground/notebooks/unitycatalog-delta.py"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@ This project makes use of the open source Unity Catalog project and introduces a
 
 ---
 
+## Build the Docker Environment
+
+```bash
+docker build -t marimo-spark .
+```
+
+## Run the Environment
+```bash
+docker compose up
+```
+
 ## Catalog Managed Tables — Python Helpers
 
 The helper module at [`delta/python/catalog-managed.py`](delta/python/catalog-managed.py) provides a set of reusable utilities for creating and populating catalog-managed Delta tables via PySpark. These same helpers are used interactively in the [`marimo-playground/notebooks/unitycatalog-delta.py`](marimo-playground/notebooks/unitycatalog-delta.py) notebook.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,11 +12,31 @@ services:
     volumes:
       - type: bind
         source: ./etc/conf/server.properties
-        target: /opt/unitycatalog/etc/conf/server.properties
-      
+        target: /home/unitycatalog/etc/conf/server.properties
+      # todo add a long-term database here since it can 
+      # trip up the process when spinning the environment back up.
       - type: volume
         source: unitycatalog_data
-        target: /opt/unitycatalog/etc/data
+        target: /home/unitycatalog/etc/data
+    networks:
+      - unity
+
+  marimo-spark:
+    image: marimo-spark:latest
+    hostname: marimo-spark
+    container_name: marimo-spark
+    #volumes:
+    #  - type: bind
+    #    source: ./marimo-playground/notebooks/
+    #    target: /marimo-playground/notebooks/
+    ports:
+      - "2718:2718"
+    networks:
+      - unity
+
+networks:
+  unity:
+    driver: bridge
 
 volumes:
   # Persist docker volume across container restarts

--- a/etc/conf/server.properties
+++ b/etc/conf/server.properties
@@ -20,7 +20,7 @@ server.cookie-timeout=P5D
 # Default: false (disabled)
 server.managed-table.enabled=true
 
-storage-root.tables=file:///home/unitycatalog/etc/data/
+storage-root.tables=/home/unitycatalog/etc/data/
 
 #### AWS credential configs
 

--- a/marimo-playground/notebooks/unitycatalog-delta.py
+++ b/marimo-playground/notebooks/unitycatalog-delta.py
@@ -61,7 +61,8 @@ def _():
 
 @app.cell
 def _():
-    unity_catalog_server_url = "http://localhost:8080"
+    # if you're running this without the docker compose file, you'll need to change this to the url of your Unity Catalog server
+    unity_catalog_server_url = "http://unitycatalog:8080"
 
     catalog = 'unity'
     schema = 'default'
@@ -106,6 +107,12 @@ def _(mo):
     1. We `should` create a new `Schema` in our `catalog` called `sanctuary`. This is where we will track the animals we are rescuing and their current status.
     2. Once we have our `unity.sanctuary` location created, we can start to work with our Pet data.
     """)
+    return
+
+
+@app.cell
+def _(spark: "SparkSession"):
+    spark.catalog.listCatalogs()
     return
 
 
@@ -492,6 +499,34 @@ def _(mo):
 def _(dt):
     # this will fail at this point in time (Delta 4.1 with Unity Catalog 0.4.0)
     dt.vacuum()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Cleaning up Tables and Schemas
+    When you are all done with your table and it is time to retire it. Then you'll need to delete the table (or tables) prior to removing the schema from Unity Catalog.
+
+    1. Let's drop the `unity.sanctuary.pets` first
+    2. Then we can remove the `schema` (`unity.sanctuary`)
+
+    Just enable the disabled cells (using the `...`) icon and run them.
+    """)
+    return
+
+
+@app.cell(disabled=True)
+def _(spark: "SparkSession"):
+    spark.sql(f"""
+    DROP TABLE unity.sanctuary.pets
+    """)
+    return
+
+
+@app.cell(disabled=True)
+def _(spark: "SparkSession"):
+    spark.sql("DROP SCHEMA unity.sanctuary")
     return
 
 


### PR DESCRIPTION
end to end flow works out of the box.

I'll follow up with an additional PR to shave off the final friction point.

Right now when you spin up the environment, the Unity Catalog server database is internal to the docker container. This causes issues with "records" that don't reflect the file system since the file system is using an docker volume. 

The fix right now is to delete the table and schema from UC (as a work around) if you're going back for a second run after stopping the container. This is not great for the user experience